### PR TITLE
Correção do menu

### DIFF
--- a/css/basalstyle/style.min.css
+++ b/css/basalstyle/style.min.css
@@ -2,7 +2,7 @@
 /* Etiquetas HTML obs: Não é necessário aplicar o CSS RESET com este código na página.  */
 html { font-size: 62.5%; background-color: #ffffff; }
 
-body { color: #111100; font-size: 1em; line-height: 1.5em; font-family: sans-serif; margin: 0; padding: 0; }
+body { color: #111100; font-size: 0em; line-height: 1.5em; font-family: sans-serif; margin: 0; padding: 0; }
 
 /* Titulagem */
 h1 { font-size: 4.0em; line-height: 60px; min-height: 90px; padding: 13px 0 17px; }
@@ -300,8 +300,8 @@ header, menu, nav, article, section, aside, details, figcaption, figure, footer 
 
 /* Altura mínima do elemento HTML.  Uso: Tem momentos que você precisa de uma altura mínima no elemento HTML. Esta classe especifica a altura mínima com valor múltiplo da entrelinha, sem limitar o conteúdo, caso cresça em tamanho e quantidade de elementos. Ex: Um uso comum: <div class="row min-h-7">  */
 .min-h-1, .form-row.min-h-1 { min-height: 30px; }
-
-.min-h-2, .form-row.min-h-2 { min-height: 60px; }
+/* controla a largura da faixa branca do menu*/
+.min-h-2, .form-row.min-h-2 { min-height: 40px; }
 
 .min-h-3, .form-row.min-h-3 { min-height: 90px; }
 

--- a/css/style.css
+++ b/css/style.css
@@ -184,6 +184,8 @@ section header h2 {
 
 /*header*/
 .header-frame  {
+	padding:0;
+	margin:0;
     background-color: #3498db;
     position: fixed;
     background-color: #FFFFFF;

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
 	
 	<body>
 		<div class="header-frame header-frame-absolute  row">
-            <header class="header header-inline min-h-2 row desktop-12 container" role="banner">
+            <header class="header header-inline min-h-2 row desktop-12 menu container" role="banner">
 				<div class="site-logo">
 					<h1>
 						<a href="/" rel="home">Empresa Jovem</a>


### PR DESCRIPTION
Foi corrigida a largura da faixa do menu, classe encontrada dentro da pasta basalstyle/style.min.css.

`.min-h-2, .form-row.min-h-2 { min-height: 40px; }` 

> era 60px e agora 40px

Para acertar o alinhamento do menu dentro da classe body o font-size foi definido como 0em, porém o que ocasionou no sumiço dos títulos Missão, Valores e Visão; e do endereço no rodapé da página.

Será preciso formatar esses textos mais a frente.